### PR TITLE
feat(effects): FadeOut component and fade_out_system (#69)

### DIFF
--- a/app/core/src/components/effects.rs
+++ b/app/core/src/components/effects.rs
@@ -36,7 +36,17 @@ pub struct FadeOut {
 
 impl FadeOut {
     /// Creates a new [`FadeOut`] that completes in `duration_secs` seconds.
+    ///
+    /// # Panics (debug only)
+    ///
+    /// Asserts that `duration_secs > 0.0` in debug builds. Passing zero or a
+    /// negative value creates a timer that is already finished, causing the
+    /// entity to be despawned on the first tick without any visible fade.
     pub fn new(duration_secs: f32) -> Self {
+        debug_assert!(
+            duration_secs > 0.0,
+            "FadeOut duration must be positive for a visible fade effect (got {duration_secs})"
+        );
         Self {
             timer: Timer::from_seconds(duration_secs, TimerMode::Once),
         }

--- a/app/core/src/components/effects.rs
+++ b/app/core/src/components/effects.rs
@@ -37,15 +37,16 @@ pub struct FadeOut {
 impl FadeOut {
     /// Creates a new [`FadeOut`] that completes in `duration_secs` seconds.
     ///
-    /// # Panics (debug only)
+    /// # Panics
     ///
-    /// Asserts that `duration_secs > 0.0` in debug builds. Passing zero or a
-    /// negative value creates a timer that is already finished, causing the
-    /// entity to be despawned on the first tick without any visible fade.
+    /// Panics if `duration_secs` is not finite or is not greater than `0.0`.
+    /// Passing zero, a negative value, or a non-finite value (NaN / infinity)
+    /// would create a timer that is immediately finished, causing the entity to
+    /// be despawned on the first tick without any visible fade.
     pub fn new(duration_secs: f32) -> Self {
-        debug_assert!(
-            duration_secs > 0.0,
-            "FadeOut duration must be positive for a visible fade effect (got {duration_secs})"
+        assert!(
+            duration_secs.is_finite() && duration_secs > 0.0,
+            "FadeOut duration must be finite and > 0.0 (got {duration_secs})"
         );
         Self {
             timer: Timer::from_seconds(duration_secs, TimerMode::Once),

--- a/app/core/src/components/effects.rs
+++ b/app/core/src/components/effects.rs
@@ -1,0 +1,106 @@
+use bevy::prelude::*;
+
+/// Causes an entity's [`Sprite`] to fade from full opacity to transparent
+/// over a fixed duration, then despawns the entity.
+///
+/// Attach this component to any entity with a [`Sprite`] that should
+/// gracefully fade out rather than instantly disappear.
+///
+/// # Life-cycle
+///
+/// ```text
+/// Spawned with FadeOut
+///   │  fade_out_system ticks timer every frame
+///   │  α = 1.0 − fraction()
+///   ▼
+/// timer.just_finished() → despawn
+/// ```
+///
+/// # Usage
+///
+/// ```rust,ignore
+/// commands.entity(entity).insert(FadeOut::new(0.3));
+/// ```
+///
+/// # Fields
+///
+/// | Field   | Description |
+/// |---------|-------------|
+/// | `timer` | Tracks elapsed / duration; exposes `.elapsed_secs()` and `.duration()` |
+#[derive(Component, Debug, Clone)]
+pub struct FadeOut {
+    /// Countdown timer — `elapsed_secs()` / `duration()` give the current
+    /// progress fraction used to compute the alpha value each frame.
+    pub timer: Timer,
+}
+
+impl FadeOut {
+    /// Creates a new [`FadeOut`] that completes in `duration_secs` seconds.
+    pub fn new(duration_secs: f32) -> Self {
+        Self {
+            timer: Timer::from_seconds(duration_secs, TimerMode::Once),
+        }
+    }
+
+    /// Total duration of the fade in seconds.
+    pub fn duration_secs(&self) -> f32 {
+        self.timer.duration().as_secs_f32()
+    }
+
+    /// Seconds elapsed since the fade began.
+    pub fn elapsed_secs(&self) -> f32 {
+        self.timer.elapsed_secs()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A freshly created FadeOut has zero elapsed time.
+    #[test]
+    fn new_fade_out_starts_at_zero_elapsed() {
+        let fade = FadeOut::new(1.0);
+        assert_eq!(fade.elapsed_secs(), 0.0);
+    }
+
+    /// duration_secs matches the value passed to new().
+    #[test]
+    fn duration_matches_constructor() {
+        let fade = FadeOut::new(2.5);
+        assert!((fade.duration_secs() - 2.5).abs() < 1e-6);
+    }
+
+    /// Alpha fraction should be 1.0 at the start and 0.0 at finish.
+    #[test]
+    fn alpha_fraction_range() {
+        let mut fade = FadeOut::new(1.0);
+        // Start: fraction == 0.0 → alpha == 1.0.
+        assert_eq!(fade.timer.fraction(), 0.0);
+        assert!((1.0 - fade.timer.fraction() - 1.0).abs() < 1e-6);
+
+        // Tick almost to the end.
+        fade.timer.tick(std::time::Duration::from_secs_f32(0.999));
+        let alpha = 1.0 - fade.timer.fraction();
+        assert!(
+            alpha >= 0.0 && alpha <= 1.0,
+            "alpha must stay in [0, 1] during fade, got {alpha}"
+        );
+
+        // Tick past the end.
+        fade.timer.tick(std::time::Duration::from_secs_f32(0.1));
+        assert!(fade.timer.is_finished());
+    }
+
+    /// Positive duration must be accepted.
+    #[test]
+    fn new_with_short_duration() {
+        let fade = FadeOut::new(0.3);
+        assert!((fade.duration_secs() - 0.3).abs() < 1e-6);
+        assert!(!fade.timer.is_finished());
+    }
+}

--- a/app/core/src/components/mod.rs
+++ b/app/core/src/components/mod.rs
@@ -1,5 +1,6 @@
 pub mod boss;
 pub mod bullet;
+pub mod effects;
 pub mod enemy;
 pub mod item;
 pub mod player;
@@ -9,6 +10,7 @@ pub use bullet::{
     BulletEmitter, BulletPattern, BulletTrail, BulletVelocity, DespawnOutOfBounds, EnemyBullet,
     EnemyBulletKind, PlayerBullet, ShootTimer,
 };
+pub use effects::FadeOut;
 pub use enemy::{Enemy, EnemyKind, EnemyMovement};
 pub use item::{ItemKind, ItemPhysics};
 pub use player::{GrazeVisual, InvincibilityTimer, Player, PlayerStats};

--- a/app/core/src/lib.rs
+++ b/app/core/src/lib.rs
@@ -15,8 +15,8 @@ pub mod systems;
 pub use components::{
     Boss, BossMovement, BossPhaseData, BossType, BulletEmitter, BulletPattern, BulletTrail,
     BulletVelocity, DespawnOutOfBounds, Enemy, EnemyBullet, EnemyBulletKind, EnemyKind,
-    EnemyMovement, GameSessionEntity, GrazeVisual, InvincibilityTimer, ItemKind, ItemPhysics,
-    Player, PlayerBullet, PlayerStats, ShootTimer,
+    EnemyMovement, FadeOut, GameSessionEntity, GrazeVisual, InvincibilityTimer, ItemKind,
+    ItemPhysics, Player, PlayerBullet, PlayerStats, ShootTimer,
 };
 pub use config::{
     EnemyBulletConfig, EnemyBulletConfigHandle, EnemyBulletConfigParams, FodderEnemyConfig,
@@ -252,7 +252,11 @@ impl Plugin for ScarletCorePlugin {
 
         app.add_systems(
             Update,
-            systems::player::update_invincibility.in_set(GameSystemSet::Effects),
+            (
+                systems::player::update_invincibility,
+                systems::effects::fade_out_system,
+            )
+                .in_set(GameSystemSet::Effects),
         );
 
         // Danmaku emitter systems.

--- a/app/core/src/systems/bomb.rs
+++ b/app/core/src/systems/bomb.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 
 use crate::{
-    components::bullet::EnemyBullet,
+    components::{bullet::EnemyBullet, effects::FadeOut},
     events::BombUsedEvent,
     resources::{BOMB_DURATION_SECS, BOMB_INVINCIBLE_SECS, BombState, GameData},
     states::AppState,
@@ -126,25 +126,33 @@ pub fn bomb_active_system(mut bomb_state: ResMut<BombState>, time: Res<Time>) {
 // bomb_effect_system
 // ---------------------------------------------------------------------------
 
-/// While the bomb is active, despawns all enemy bullets and awards 10 points
+/// Duration of the bullet fade-out effect applied by the bomb (seconds).
+const BOMB_BULLET_FADE_SECS: f32 = 0.3;
+
+/// While the bomb is active, fades out all enemy bullets and awards 10 points
 /// per bullet cleared.
 ///
+/// Bullets that do not yet have a [`FadeOut`] component receive one with a
+/// short [`BOMB_BULLET_FADE_SECS`] duration. The `Without<FadeOut>` filter
+/// prevents double-counting bullets across consecutive frames of a bomb.
+/// [`crate::systems::effects::fade_out_system`] handles the alpha decay and
+/// final despawn once the timer expires.
+///
 /// Running every frame while `bomb_state.active` ensures that bullets spawned
-/// during the bomb (e.g. from a boss emitter that was not yet silenced) are
-/// also cleared.
+/// during the bomb (e.g. from a boss emitter that was not yet silenced in the
+/// same frame) are also faded.
 ///
 /// # Score
 ///
-/// Each cleared bullet awards 10 points, consistent with the Phase 09
-/// specification. Score is added directly to [`GameData::score`]; no event is
-/// emitted for individual bullets.
+/// Each bullet that starts fading awards 10 points immediately. Score is added
+/// directly to [`GameData::score`]; no event is emitted for individual bullets.
 ///
 /// Registered in [`crate::GameSystemSet::GameLogic`] so it runs after
 /// [`crate::GameSystemSet::Collision`] — graze counts are finalised before
-/// bullets are removed.
+/// bullets begin fading.
 pub fn bomb_effect_system(
     mut commands: Commands,
-    enemy_bullets: Query<Entity, With<EnemyBullet>>,
+    enemy_bullets: Query<Entity, (With<EnemyBullet>, Without<FadeOut>)>,
     bomb_state: Res<BombState>,
     mut game_data: ResMut<GameData>,
 ) {
@@ -154,7 +162,9 @@ pub fn bomb_effect_system(
 
     let mut cleared: u64 = 0;
     for entity in &enemy_bullets {
-        commands.entity(entity).despawn();
+        commands
+            .entity(entity)
+            .insert(FadeOut::new(BOMB_BULLET_FADE_SECS));
         cleared += 1;
     }
 

--- a/app/core/src/systems/collision.rs
+++ b/app/core/src/systems/collision.rs
@@ -6,6 +6,7 @@ use crate::{
     components::{
         boss::Boss,
         bullet::{EnemyBullet, EnemyBulletKind, PlayerBullet},
+        effects::FadeOut,
         enemy::Enemy,
         player::{InvincibilityTimer, Player, PlayerStats},
     },
@@ -14,6 +15,26 @@ use crate::{
     events::{BossHitEvent, EnemyDefeatedEvent, GrazeEvent, PlayerHitEvent},
     resources::{BombState, COUNTER_BOMB_WINDOW_SECS, GameData},
 };
+
+// ---------------------------------------------------------------------------
+// Query type aliases
+// ---------------------------------------------------------------------------
+
+/// Active (non-fading) enemy bullets suitable for hit detection.
+type ActiveEnemyBullets<'w, 's> = Query<
+    'w,
+    's,
+    (&'static Transform, &'static EnemyBulletKind),
+    (With<EnemyBullet>, Without<FadeOut>),
+>;
+
+/// Active (non-fading) enemy bullets with entity ID, used for graze detection.
+type ActiveEnemyBulletsWithEntity<'w, 's> = Query<
+    'w,
+    's,
+    (Entity, &'static Transform, &'static EnemyBulletKind),
+    (With<EnemyBullet>, Without<FadeOut>),
+>;
 
 // ---------------------------------------------------------------------------
 // Collision utility
@@ -190,7 +211,7 @@ pub fn player_bullet_hit_boss(
 /// Registered in [`crate::GameSystemSet::Collision`].
 pub fn player_hit_detection(
     player: Query<(&Transform, &PlayerStats, Option<&InvincibilityTimer>), With<Player>>,
-    bullets: Query<(&Transform, &EnemyBulletKind), With<EnemyBullet>>,
+    bullets: ActiveEnemyBullets,
     mut hit_events: MessageWriter<PlayerHitEvent>,
     enemy_bullet_cfg: EnemyBulletConfigParams,
     bomb_state: Res<BombState>,
@@ -304,7 +325,7 @@ pub fn handle_player_hit(
 /// Registered in [`crate::GameSystemSet::Collision`].
 pub fn graze_detection_system(
     player: Query<(&Transform, &PlayerStats), With<Player>>,
-    bullets: Query<(Entity, &Transform, &EnemyBulletKind), With<EnemyBullet>>,
+    bullets: ActiveEnemyBulletsWithEntity,
     mut game_data: ResMut<GameData>,
     mut graze_set: Local<HashSet<Entity>>,
     mut graze_events: MessageWriter<GrazeEvent>,

--- a/app/core/src/systems/effects.rs
+++ b/app/core/src/systems/effects.rs
@@ -1,0 +1,39 @@
+use bevy::prelude::*;
+
+use crate::components::effects::FadeOut;
+
+// ---------------------------------------------------------------------------
+// fade_out_system
+// ---------------------------------------------------------------------------
+
+/// Ticks every [`FadeOut`] timer and linearly decreases the [`Sprite`] alpha.
+///
+/// Each frame the system computes `alpha = 1.0 - timer.fraction()` and writes
+/// it to [`Sprite::color`]. When the timer finishes the entity is despawned.
+///
+/// # Requirements
+///
+/// The entity must have both a [`FadeOut`] and a [`Sprite`] component.
+/// Entities with [`FadeOut`] but no [`Sprite`] are silently ignored.
+///
+/// # Ordering
+///
+/// Registered in [`crate::GameSystemSet::Effects`] so it runs after all
+/// gameplay and collision logic but before cleanup, ensuring the alpha is
+/// up-to-date when rendered.
+pub fn fade_out_system(
+    mut commands: Commands,
+    mut query: Query<(Entity, &mut Sprite, &mut FadeOut)>,
+    time: Res<Time>,
+) {
+    for (entity, mut sprite, mut fade) in &mut query {
+        fade.timer.tick(time.delta());
+
+        let alpha = 1.0 - fade.timer.fraction();
+        sprite.color = sprite.color.with_alpha(alpha);
+
+        if fade.timer.just_finished() {
+            commands.entity(entity).despawn();
+        }
+    }
+}

--- a/app/core/src/systems/mod.rs
+++ b/app/core/src/systems/mod.rs
@@ -4,6 +4,7 @@ pub mod bullet;
 pub mod cleanup;
 pub mod collision;
 pub mod danmaku;
+pub mod effects;
 pub mod enemy;
 pub mod item;
 pub mod loading;


### PR DESCRIPTION
## 概要

Issue #69: `FadeOut` コンポーネントとフェードアウトシステムを実装します。

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `components/effects.rs` | `FadeOut { timer: Timer }` コンポーネント |
| `systems/effects.rs` | `fade_out_system` (Effects セット) |
| `systems/bomb.rs` | `bomb_effect_system` を即時 despawn → `FadeOut` 挿入に変更 |
| `components/mod.rs` | `FadeOut` を re-export |
| `systems/mod.rs` | `effects` モジュール追加 |
| `lib.rs` | `FadeOut` を pub use、`fade_out_system` を Effects セットに登録 |

## 設計

```
FadeOut { timer: Timer }
  ├── new(duration_secs: f32) — タイマー初期化
  ├── duration_secs() — 合計時間（秒）
  └── elapsed_secs()  — 経過時間（秒）

fade_out_system (Effects セット):
  各フレーム: alpha = 1.0 - timer.fraction()
  timer.just_finished() → despawn
```

## ボム弾消去への適用

`bomb_effect_system` を変更:
- `commands.entity(entity).despawn()` → `commands.entity(entity).insert(FadeOut::new(0.3))`
- `Without<FadeOut>` フィルタでフレームをまたいだ重複カウントを防止
- スコア加算は `FadeOut` 追加時に即時実行（0.3 秒後の despawn ではなく）

## 関連 Issue

Closes #69 

## テスト

- 初期経過時間 0.0 の確認
- `duration_secs()` がコンストラクタ引数に一致
- alpha が `[0, 1]` 範囲内を維持
- 短い duration での初期化

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enemy bullets now fade out smoothly instead of disappearing instantly, improving visual polish and feedback.
  * A global fade-out effect enables gradual sprite transparency transitions for effects across the game.

* **Bug Fixes**
  * Scoring and hit/graze detection no longer double-count or interact with bullets already fading, making behavior more consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->