### PR TITLE
feat(core): ステージクリアハンドラーの実装（暫定）+ ボス未出現バグ修正

### DIFF
--- a/app/core/src/constants.rs
+++ b/app/core/src/constants.rs
@@ -12,3 +12,15 @@ pub const PLAY_AREA_HALF_W: f32 = PLAY_AREA_WIDTH / 2.0;
 
 /// Half-height of the play area (used for boundary clamping).
 pub const PLAY_AREA_HALF_H: f32 = PLAY_AREA_HEIGHT / 2.0;
+
+/// Total number of main stages in the game.
+///
+/// Stage 6 (Remilia Scarlett) is the final stage; clearing it triggers
+/// the ending sequence instead of continuing to a next stage.
+pub const TOTAL_STAGES: u8 = 6;
+
+/// Score bonus awarded to the player when a stage boss is defeated.
+///
+/// This is a provisional flat bonus applied in [`crate::systems::stage_clear`].
+/// The value may be tuned or replaced with a dynamic formula in a future issue.
+pub const STAGE_CLEAR_SCORE_BONUS: u64 = 100_000;

--- a/app/core/src/lib.rs
+++ b/app/core/src/lib.rs
@@ -24,7 +24,10 @@ pub use config::{
     GameRulesConfigParams, PlayerBulletConfig, PlayerBulletConfigHandle, PlayerBulletConfigParams,
     PlayerConfig, PlayerConfigHandle, PlayerConfigParams, ScarletConfigPlugin,
 };
-pub use constants::{PLAY_AREA_HALF_H, PLAY_AREA_HALF_W, PLAY_AREA_HEIGHT, PLAY_AREA_WIDTH};
+pub use constants::{
+    PLAY_AREA_HALF_H, PLAY_AREA_HALF_W, PLAY_AREA_HEIGHT, PLAY_AREA_WIDTH, STAGE_CLEAR_SCORE_BONUS,
+    TOTAL_STAGES,
+};
 pub use events::{
     BombUsedEvent, BossHitEvent, BossPhaseChangedEvent, BossSpawnEvent, EnemyDefeatedEvent,
     ExtendEvent, ExtendKind, GrazeEvent, PlayerHitEvent, ShootEvent,
@@ -282,6 +285,13 @@ impl Plugin for ScarletCorePlugin {
         app.add_systems(
             OnExit(AppState::Playing),
             systems::cleanup::cleanup_game_session,
+        );
+
+        // Stage-clear handler: awards bonus, updates hi_score, and either
+        // advances to the next stage or transitions to Ending on the final stage.
+        app.add_systems(
+            OnEnter(AppState::StageClear),
+            systems::stage_clear::on_stage_clear,
         );
 
         #[cfg(feature = "debug-hitbox")]

--- a/app/core/src/shaders/plugin.rs
+++ b/app/core/src/shaders/plugin.rs
@@ -5,7 +5,7 @@ use crate::game_set::GameSystemSet;
 use crate::{
     components::player::{GrazeVisual, Player},
     events::{BossHitEvent, GrazeEvent},
-    resources::{BombState, BOMB_DURATION_SECS},
+    resources::{BOMB_DURATION_SECS, BombState},
     shaders::{
         BombMarisaMaterial, BombMarisaVisual, BombReimuMaterial, BombReimuVisual,
         BulletGlowMaterial, BulletTrailMaterial, GrazeMaterial, HitFlashMaterial,
@@ -365,11 +365,7 @@ pub fn update_bomb_reimu_material(
     let t = time.elapsed_secs();
     let frac = bomb_state.active_timer.fraction();
     // Stay at full opacity for the first 70 %, then fade out to 0.
-    let intensity = if frac < 0.7 {
-        1.0
-    } else {
-        (1.0 - frac) / 0.3
-    };
+    let intensity = if frac < 0.7 { 1.0 } else { (1.0 - frac) / 0.3 };
     // Start at 0.3 (already visible) and expand to 1.0 with a sqrt curve
     // so the barrier feels explosive early and slows as it fills the area.
     let expand_radius = 0.3 + 0.7 * frac.sqrt();
@@ -404,11 +400,7 @@ pub fn update_bomb_marisa_material(
     }
     let t = time.elapsed_secs();
     let frac = bomb_state.active_timer.fraction();
-    let intensity = if frac < 0.7 {
-        1.0
-    } else {
-        (1.0 - frac) / 0.3
-    };
+    let intensity = if frac < 0.7 { 1.0 } else { (1.0 - frac) / 0.3 };
     // Ramp width up over the first 0.3 s of the bomb (≈ 8.6 % of 3.5 s).
     let width_ramp_frac = 0.3 / BOMB_DURATION_SECS;
     let width = (frac / width_ramp_frac).min(1.0);

--- a/app/core/src/systems/boss/bosses/rumia.rs
+++ b/app/core/src/systems/boss/bosses/rumia.rs
@@ -8,7 +8,6 @@ use crate::{
         enemy::Enemy,
     },
     events::BossSpawnEvent,
-    resources::StageData,
 };
 
 // ---------------------------------------------------------------------------
@@ -208,16 +207,12 @@ pub fn spawn_rumia(commands: &mut Commands) {
 pub fn on_boss_spawn_stage1(
     mut commands: Commands,
     mut boss_events: MessageReader<BossSpawnEvent>,
-    mut stage_data: ResMut<StageData>,
 ) {
     for event in boss_events.read() {
-        // Skip other stages and guard against duplicate messages in the same frame.
-        if event.stage_number != 1 || stage_data.boss_active {
+        if event.stage_number != 1 {
             continue;
         }
         spawn_rumia(&mut commands);
-        // Mark the boss as active so stage_control_system can track defeat.
-        stage_data.boss_active = true;
     }
 }
 

--- a/app/core/src/systems/mod.rs
+++ b/app/core/src/systems/mod.rs
@@ -12,3 +12,4 @@ pub mod player;
 pub mod reset;
 pub mod score;
 pub mod stage;
+pub mod stage_clear;

--- a/app/core/src/systems/stage_clear.rs
+++ b/app/core/src/systems/stage_clear.rs
@@ -1,0 +1,69 @@
+//! Stage-clear handler: runs once when `AppState::StageClear` is entered.
+//!
+//! Responsibilities (provisional — Phase 10):
+//! * Award the flat [`STAGE_CLEAR_SCORE_BONUS`] to the player's score.
+//! * Update `hi_score` if the current score exceeds it.
+//! * If the cleared stage was the final stage, transition to
+//!   [`AppState::Ending`].
+//! * Otherwise, increment [`StageData::stage_number`] so the next
+//!   `OnEnter(AppState::Playing)` load system prepares the correct stage.
+//!
+//! The StageClear UI screen (results display, continue prompt) is tracked in a
+//! separate issue. For now, the transition away from StageClear is driven
+//! externally (UI not yet implemented).
+
+use bevy::prelude::*;
+
+use crate::{
+    constants::{STAGE_CLEAR_SCORE_BONUS, TOTAL_STAGES},
+    resources::{GameData, StageData},
+    states::AppState,
+};
+
+/// Runs on `OnEnter(AppState::StageClear)`.
+///
+/// Awards the stage-clear bonus, updates `hi_score`, and either advances the
+/// stage number or (for the final stage) triggers the ending transition.
+pub fn on_stage_clear(
+    mut game_data: ResMut<GameData>,
+    mut stage_data: ResMut<StageData>,
+    mut next_state: ResMut<NextState<AppState>>,
+) {
+    game_data.score += STAGE_CLEAR_SCORE_BONUS;
+    if game_data.score > game_data.hi_score {
+        game_data.hi_score = game_data.score;
+    }
+
+    if stage_data.stage_number >= TOTAL_STAGES {
+        info!(
+            stage = stage_data.stage_number,
+            "Final stage cleared — transitioning to Ending"
+        );
+        next_state.set(AppState::Ending);
+    } else {
+        let next = stage_data.stage_number + 1;
+        info!(
+            cleared = stage_data.stage_number,
+            next = next,
+            "Stage cleared — advancing to stage {next}"
+        );
+        stage_data.stage_number = next;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Score bonus must match the public constant.
+    #[test]
+    fn stage_clear_score_bonus_is_positive() {
+        assert!(STAGE_CLEAR_SCORE_BONUS > 0);
+    }
+
+    /// TOTAL_STAGES must cover the six EoSD stages.
+    #[test]
+    fn total_stages_is_six() {
+        assert_eq!(TOTAL_STAGES, 6);
+    }
+}


### PR DESCRIPTION
## 概要

Issue #72 のステージクリアハンドラー（暫定版）を実装する。ボス撃破後に `AppState::StageClear` へ遷移し、スコアボーナス加算・次ステージ番号設定・最終ステージ時の `AppState::Ending` 遷移を処理する。あわせて、ボスが一切出現しなかったバグを修正した。

## 変更内容

**feat: ステージクリアハンドラー（Issue #72）**
- `TOTAL_STAGES = 6`、`STAGE_CLEAR_SCORE_BONUS = 100_000` 定数を追加
- `on_stage_clear` システムを新規追加（`OnEnter(AppState::StageClear)` で実行）
  - スコアボーナスを加算し `hi_score` を更新
  - 最終ステージ（Stage 6）なら `AppState::Ending` へ遷移
  - それ以外は `stage_data.stage_number` をインクリメント

**fix: ボスが出現しないバグ（`on_boss_spawn_stage1`）**
- 根本原因: `stage_control_system` が `BossSpawnEvent` emit 前に `boss_active = true` をセットするため、同フレーム内で `on_boss_spawn_stage1` の `boss_active` ガードが常に発火し `spawn_rumia` が呼ばれなかった
- 修正: `on_boss_spawn_stage1` から冗長な `boss_active` チェックとセットを削除（`stage_control_system` 側のガードで二重発火は防止済み）

## 関連 Issue

Closes #72

## テスト計画

- [x] `cargo test --workspace` 通過（168 tests）
- [x] `cargo clippy --workspace -- -D warnings` 通過
- [x] `cargo fmt --all` 適用済み
- [x] 実機確認: 約100秒後にルーミアが出現することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented stage-clear bonus system awarding 100,000 points upon completing a stage
  * Added stage progression logic: completing the final stage (stage 6) transitions to the ending, while earlier stages advance to the next one

* **Chores**
  * Code refactoring and internal optimizations for gameplay systems

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/itsakeyfut/touhou-project-scarlet/pull/217?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->